### PR TITLE
Update README to reflect Java 7 build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
 * validator
-  * Java 6/7
+  * Java 7
   * Maven 3 (to build)
 * make_manifest
   * Python 2.7/3.3 or higher


### PR DESCRIPTION
The validator uses nio Paths, so it no longer builds with Java 6.

Might also consider adding some Maven enforcer rules to the pom so the error message is nicer. I can do this if desired.