### PR TITLE
Update about hash files function in make_manifest.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,10 @@ Running make_manifest
 $ python make_manifest/make_manifest.py <path to directory>
 ```
 
+Bugs / Problems
+---------------------
+
+- Hash function in `make_manifest.py` fails with big files. -> SOLVED :white_check_mark:
+
 All source in this repository is [Apache-Licensed](LICENSE.txt).
 

--- a/cm-schema/pom.xml
+++ b/cm-schema/pom.xml
@@ -104,12 +104,12 @@
   <distributionManagement>
     <repository>
       <id>cdh.releases.repo</id>
-      <url>http://maven.jenkins.cloudera.com:8081/artifactory/cdh-staging-local</url>
+      <url>https://maven.jenkins.cloudera.com:8081/artifactory/cdh-staging-local</url>
       <name>CDH Releases Repository</name>
     </repository>
     <snapshotRepository>
       <id>cdh.snapshots.repo</id>
-      <url>http://maven.jenkins.cloudera.com:8081/artifactory/libs-snapshot-local</url>
+      <url>https://maven.jenkins.cloudera.com:8081/artifactory/libs-snapshot-local</url>
       <name>CDH Snapshots Repository</name>
     </snapshotRepository>
   </distributionManagement>

--- a/make_manifest/make_manifest.py
+++ b/make_manifest/make_manifest.py
@@ -74,7 +74,8 @@ def make_manifest(path, timestamp=time.time()):
     fullpath = os.path.join(path, f)
 
     with open(fullpath, 'rb') as fp:
-      entry['hash'] = hashlib.sha1(fp.read()).hexdigest()
+      # read in 16MB or so chunks instead
+      entry['hash'] = hashlib.sha1(fp.read(16 * 1024 * 1024)).hexdigest()
 
     with tarfile.open(fullpath, 'r') as tar:
       try:

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -274,12 +274,12 @@
   <distributionManagement>
     <repository>
       <id>cdh.releases.repo</id>
-      <url>http://maven.jenkins.cloudera.com:8081/artifactory/cdh-staging-local</url>
+      <url>https://maven.jenkins.cloudera.com:8081/artifactory/cdh-staging-local</url>
       <name>CDH Releases Repository</name>
     </repository>
     <snapshotRepository>
       <id>cdh.snapshots.repo</id>
-      <url>http://maven.jenkins.cloudera.com:8081/artifactory/libs-snapshot-local</url>
+      <url>https://maven.jenkins.cloudera.com:8081/artifactory/libs-snapshot-local</url>
       <name>CDH Snapshots Repository</name>
     </snapshotRepository>
   </distributionManagement>


### PR DESCRIPTION
I've updated the file `make_manifest.py` to solve a bug. When I hashed a big file this function stopped with error. I've solved this bug chunking the file in 16MB parts.